### PR TITLE
chore: adding fallback to search container-name

### DIFF
--- a/translations/translations_pt.json
+++ b/translations/translations_pt.json
@@ -5,15 +5,14 @@
   "login_previous_profile": "Fazer login com o perfil escolhido anteriormente",
   "exit": "Sair",
   "invalid_option": "Opção inválida. Por favor escolha uma válida.",
-  "you_selected_profile": "Você selecionou o perfil: ",
+  "you_selected_profile": "Você selecionou o perfil:",
   "no_clusters_found": "Não foi possível listar os clusters para o perfil selecionado.",
   "choose_cluster": "Escolha um cluster:",
   "choose_service": "Escolha um serviço:",
   "no_active_tasks": "Não há tasks ativas para o serviço selecionado.",
   "choose_task": "Escolha uma task:",
-  "task_id_is": "O ID da task é: ",
+  "task_id_is": "O ID da task é:",
   "choose_valid_task": "Escolha uma task válida.",
   "bye": "Tchau!",
   "execute_command_not_enabled": "O comando execute falhou porque não estava habilitado quando a tarefa foi iniciada ou o agente não está em execução. Espere e tente novamente ou execute uma nova tarefa com execute command habilitado."
 }
-


### PR DESCRIPTION
When getting the container name, it sometimes returns the original name and not the override name. In each service, the choice of name is variable so it was added to first try to connect with the override name and if it doesn't work, try with the original name

<img width="321" alt="image" src="https://github.com/kleytonmr/ecs-task-management/assets/31089959/5c06757c-2048-4fb5-b8b3-e3161cf7742c">
