### PR TITLE
Rewrite command picking logic

### DIFF
--- a/ecs_tasks.sh
+++ b/ecs_tasks.sh
@@ -27,7 +27,6 @@ load_translations() {
   bye=$(jq -r '.bye' "$lang_file")
   command="command -v launcher && launcher bash || /bin/bash"
   execute_command_not_enabled=$(jq -r '.execute_command_not_enabled' "$lang_file")
-  command_execute_error=$(jq -r '.command_execute_error' "$lang_file")
 }
 
 echo "1) Português"

--- a/ecs_tasks.sh
+++ b/ecs_tasks.sh
@@ -25,6 +25,7 @@ load_translations() {
   choose_task=$(jq -r '.choose_task' "$lang_file")
   task_id_is=$(jq -r '.task_id_is' "$lang_file")
   bye=$(jq -r '.bye' "$lang_file")
+  command="command -v launcher && launcher bash || /bin/bash"
   execute_command_not_enabled=$(jq -r '.execute_command_not_enabled' "$lang_file")
   command_execute_error=$(jq -r '.command_execute_error' "$lang_file")
 }
@@ -170,15 +171,5 @@ aws ecs execute-command \
   --cluster $cluster_name \
   --task $task_id \
   --container $container_name \
-  --command 'launcher bash' \
-  --interactive --profile $profile
-
-echo "$command_execute_error"
-
-aws ecs execute-command \
-  --region us-east-1 \
-  --cluster $cluster_name \
-  --task $task_id \
-  --container $container_name \
-  --command '/bin/bash' \
+  --command $command \
   --interactive --profile $profile

--- a/translations/translations_en.json
+++ b/translations/translations_en.json
@@ -1,5 +1,4 @@
 {
-  "command_execute_error": "Execution with bash launcher failed. Trying with '/bin/bash'...",
   "choose_profile": "Choose an AWS profile:",
   "new_profile": "New profile (aws configure sso)",
   "configure_sso": "Configure AWS SSO",

--- a/translations/translations_es-419.json
+++ b/translations/translations_es-419.json
@@ -1,5 +1,4 @@
 {
-  "command_execute_error": "Falló la ejecución con el iniciador de bash. Probando con '/bin/bash'...",
   "choose_profile": "Elija un perfil de AWS:",
   "new_profile": "Nuevo perfil (aws configure sso)",
   "configure_sso": "Configurar AWS SSO",

--- a/translations/translations_pt.json
+++ b/translations/translations_pt.json
@@ -1,5 +1,4 @@
 {
-  "command_execute_error": "Execução com launcher bash falhou. Tentando com '/bin/bash'...",
   "choose_profile": "Escolha um perfil AWS:",
   "new_profile": "Novo perfil (aws configure sso)",
   "configure_sso": "Configurar AWS SSO",


### PR DESCRIPTION
## Changes
* added a `$command` variable to easily fix or add new possible starter commands
* changed logic to check if the `launcher` exists and use it. Otherwise runs `/bin/bash` command
* removed the now unused `command_execute_error` translation
